### PR TITLE
Changed clock source to 16MHz external oscillator to avoid CAN not wo…

### DIFF
--- a/CAN_K2X.cpp
+++ b/CAN_K2X.cpp
@@ -73,9 +73,10 @@ CAN_K2X::CAN_K2X()
   // set up the pins, 3=PTA12=CAN0_TX, 4=PTA13=CAN0_RX
   CORE_PIN3_CONFIG = PORT_PCR_MUX(2);
   CORE_PIN4_CONFIG = PORT_PCR_MUX(2);// | PORT_PCR_PE | PORT_PCR_PS;
-  // select clock source
+  // select clock source external 16MHz oscillator
+  OSC0_CR |= OSC_ERCLKEN;
   SIM_SCGC6 |=  SIM_SCGC6_FLEXCAN0;
-  FLEXCAN0_CTRL1 |= FLEXCAN_CTRL_CLK_SRC;
+  FLEXCAN0_CTRL1 &= ~FLEXCAN_CTRL_CLK_SRC;
 
   // enable CAN
   FLEXCAN0_MCR |=  FLEXCAN_MCR_FRZ;
@@ -117,66 +118,45 @@ void CAN_K2X::end(void)
 // -------------------------------------------------------------
 void CAN_K2X::begin(uint32_t bitrate)
 {
-  // segment timings from freescale loopback test
-  if ( 33333 == bitrate )
+   if ( 33333 == bitrate )
   {
-    /*
-                            ** 48M/120= 400k sclock, 12Tq
-                            ** PROPSEG = 3, LOM = 0x0, LBUF = 0x0, TSYNC = 0x0, SAMP = 1
-                                    ** RJW = 3, PSEG1 = 4, PSEG2 = 4,PRESDIV = 120
-                            */
-    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(2)
-                      | FLEXCAN_CTRL_PSEG1(3) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(119));
+    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(1)
+                      | FLEXCAN_CTRL_PSEG1(7) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(29));
+  }
+  else if ( 50000 == bitrate )
+  {
+    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(1)
+                      | FLEXCAN_CTRL_PSEG1(7) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(19));
   }
   else if ( 83333 == bitrate )
   {
-    /*
-                             ** 48M/48= 1M sclock, 12Tq
-                             ** PROPSEG = 3, LOM = 0x0, LBUF = 0x0, TSYNC = 0x0, SAMP = 1
-                                     ** RJW = 3, PSEG1 = 4, PSEG2 = 4,PRESDIV = 48
-                             */
-    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(2)
-                      | FLEXCAN_CTRL_PSEG1(3) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(47));
+    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(1)
+                      | FLEXCAN_CTRL_PSEG1(7) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(11));
+  }
+  else if ( 100000 == bitrate )
+  {
+    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(1)
+                      | FLEXCAN_CTRL_PSEG1(7) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(9));
   }
   else if ( 250000 == bitrate )
   {
-    /*
-                             ** 48M/16= 3M sclock, 12Tq
-                             ** PROPSEG = 3, LOM = 0x0, LBUF = 0x0, TSYNC = 0x0, SAMP = 1
-                                     ** RJW = 2, PSEG1 = 4, PSEG2 = 4, PRESDIV = 16
-                             */
     FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(1)
-                      | FLEXCAN_CTRL_PSEG1(3) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(15));
+                      | FLEXCAN_CTRL_PSEG1(7) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(3));
   }
   else if ( 500000 == bitrate )
   {
-    /*
-                             ** 48M/8=6M sclock, 12Tq
-                             ** PROPSEG = 3, LOM = 0x0, LBUF = 0x0, TSYNC = 0x0, SAMP = 1
-                                     ** RJW = 2, PSEG1 = 4, PSEG2 = 4, PRESDIV = 6
-                             */
     FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(1)
-                      | FLEXCAN_CTRL_PSEG1(3) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(7));
+                      | FLEXCAN_CTRL_PSEG1(7) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(1));
   }
   else if ( 1000000 == bitrate )
   {
-    /*
-                                     ** 48M/6=8M sclock
-                                     ** PROPSEG = 4, LOM = 0x0, LBUF = 0x0, TSYNC = 0x0, SAMP = 1
-                                     ** RJW = 1, PSEG1 = 1, PSEG2 = 2, PRESCALER = 6
-                                 */
-    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(3) | FLEXCAN_CTRL_RJW(0)
-                      | FLEXCAN_CTRL_PSEG1(0) | FLEXCAN_CTRL_PSEG2(1) | FLEXCAN_CTRL_PRESDIV(5));
+   FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(0)
+                      | FLEXCAN_CTRL_PSEG1(1) | FLEXCAN_CTRL_PSEG2(1) | FLEXCAN_CTRL_PRESDIV(1));
   }
-  else     // 125000
+  else     // default to 125_000
   {
-    /*
-                           ** 48M/32= 1.5M sclock, 12Tq
-                           ** PROPSEG = 3, LOM = 0x0, LBUF = 0x0, TSYNC = 0x0, SAMP = 1
-                                   ** RJW = 3, PSEG1 = 4, PSEG2 = 4, PRESDIV = 32
-                           */
-    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(2)
-                      | FLEXCAN_CTRL_PSEG1(3) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(31));
+    FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(1)
+                      | FLEXCAN_CTRL_PSEG1(7) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(7));
   }
 
   FLEXCAN0_RXMGMASK = 0;


### PR DESCRIPTION
Teensy IDE allow to change MCU system clock but the library failed to work with clock frequency lower than 96MHz. Changing clock source to external 16MHz oscillator will fix the bug.
